### PR TITLE
Add apply_random to randomly apply rewrite matches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.8"
 smallvec = "0.6"
 indexmap = "1"
 instant = "0.1"
+rand = "0.7"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -5,9 +5,9 @@ use indexmap::IndexSet;
 use instant::Instant;
 use itertools::Itertools;
 use log::*;
+use rand::seq::SliceRandom;
 use smallvec::{smallvec, SmallVec};
 use symbolic_expressions::Sexp;
-use rand::seq::SliceRandom;
 
 use crate::{
     egraph::{AddResult, EGraph, Metadata},
@@ -282,7 +282,7 @@ impl<'a, L: Language, M: Metadata<L>> RewriteMatches<'a, L, M> {
         egraph: &mut EGraph<L, M>,
         size_limit: usize,
         amount: usize,
-        rng: &mut R
+        rng: &mut R,
     ) -> Vec<Id> {
         self.matches
             .choose_multiple(rng, amount)

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use log::*;
 use smallvec::{smallvec, SmallVec};
 use symbolic_expressions::Sexp;
+use rand::seq::SliceRandom;
 
 use crate::{
     egraph::{AddResult, EGraph, Metadata},
@@ -272,6 +273,19 @@ impl<'a, L: Language, M: Metadata<L>> RewriteMatches<'a, L, M> {
     pub fn apply_with_limit(&self, egraph: &mut EGraph<L, M>, size_limit: usize) -> Vec<Id> {
         self.matches
             .iter()
+            .flat_map(|m| self.rewrite.apply(egraph, m, size_limit))
+            .collect()
+    }
+
+    pub fn apply_random<R: rand::Rng + ?Sized>(
+        &self,
+        egraph: &mut EGraph<L, M>,
+        size_limit: usize,
+        amount: usize,
+        rng: &mut R
+    ) -> Vec<Id> {
+        self.matches
+            .choose_multiple(rng, amount)
             .flat_map(|m| self.rewrite.apply(egraph, m, size_limit))
             .collect()
     }


### PR DESCRIPTION
`apply_random` samples a given number of matches to apply per rule per iteration. This can help avoid certain rules (e.g. associativity, commutativity) exploding after a few iterations, and also give each rule more equal opportunity to grow the graph. 