### PR TITLE
Matching- skip eclasses that do not contain eclass with operator

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -144,10 +144,22 @@ where
     M: Metadata<L>,
 {
     fn search(&self, egraph: &EGraph<L, M>) -> Vec<SearchMatches> {
-        egraph
-            .classes()
-            .filter_map(|e| self.search_eclass(egraph, e.id))
-            .collect()
+	match &self.ast {
+	    PatternAst::ENode(e) => {
+		if let Some(ids) = egraph.sigtoclasses.get(&(e.op.clone(), e.children.len())) {
+		    ids.iter().filter_map(|id| self.search_eclass(egraph, *id))
+			.collect()
+		} else {
+		    vec![]
+		}
+	    },
+	    PatternAst::Var(v) => {
+		egraph
+		    .classes()
+		    .filter_map(|e| self.search_eclass(egraph, e.id))
+		    .collect()
+	    }
+	}
     }
 
     fn search_eclass(&self, egraph: &EGraph<L, M>, eclass: Id) -> Option<SearchMatches> {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -49,6 +49,9 @@ use crate::{
 /// // variable in the Pattern
 /// let same_add: Pattern<Math> = "(+ ?a ?a)".parse().unwrap();
 ///
+/// // Rebuild before searching
+/// egraph.rebuild();
+///
 /// // This is the search method from the Searcher trait
 /// let matches = same_add.search(&egraph);
 /// let matched_eclasses: Vec<Id> = matches.iter().map(|m| m.eclass).collect();
@@ -144,22 +147,21 @@ where
     M: Metadata<L>,
 {
     fn search(&self, egraph: &EGraph<L, M>) -> Vec<SearchMatches> {
-	match &self.ast {
-	    PatternAst::ENode(e) => {
-		if let Some(ids) = egraph.sigtoclasses.get(&(e.op.clone(), e.children.len())) {
-		    ids.iter().filter_map(|id| self.search_eclass(egraph, *id))
-			.collect()
-		} else {
-		    vec![]
-		}
-	    },
-	    PatternAst::Var(v) => {
-		egraph
-		    .classes()
-		    .filter_map(|e| self.search_eclass(egraph, e.id))
-		    .collect()
-	    }
-	}
+        match &self.ast {
+            PatternAst::ENode(e) => {
+                if let Some(ids) = egraph.classes_by_op.get(&(e.op.clone(), e.children.len())) {
+                    ids.iter()
+                        .filter_map(|id| self.search_eclass(egraph, *id))
+                        .collect()
+                } else {
+                    vec![]
+                }
+            }
+            PatternAst::Var(_) => egraph
+                .classes()
+                .filter_map(|e| self.search_eclass(egraph, e.id))
+                .collect(),
+        }
     }
 
     fn search_eclass(&self, egraph: &EGraph<L, M>, eclass: Id) -> Option<SearchMatches> {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -149,13 +149,11 @@ where
     fn search(&self, egraph: &EGraph<L, M>) -> Vec<SearchMatches> {
         match &self.ast {
             PatternAst::ENode(e) => {
-                if let Some(ids) = egraph.classes_by_op.get(&(e.op.clone(), e.children.len())) {
-                    ids.iter()
-                        .filter_map(|id| self.search_eclass(egraph, *id))
-                        .collect()
-                } else {
-                    vec![]
-                }
+                let key = (e.op.clone(), e.children.len());
+                let ids: &[Id] = egraph.classes_by_op.get(&key).map_or(&[], Vec::as_slice);
+                ids.iter()
+                    .filter_map(|&id| self.search_eclass(egraph, id))
+                    .collect()
             }
             PatternAst::Var(_) => egraph
                 .classes()

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -472,7 +472,9 @@ mod tests {
             "fold_add"; "(+ ?a ?b)" => { Appender }
         );
 
+        egraph.rebuild();
         fold_add.run(&mut egraph);
+        egraph.rebuild();
         assert_eq!(egraph.equivs(&start, &goal), vec![egraph.find(root)]);
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -303,6 +303,7 @@ where
     /// [`stop_reason`](#structfield.stop_reason) is guaranteeed to be
     /// set.
     pub fn run(mut self, rules: &[Rewrite<L, M>]) -> Self {
+        self.egraph.rebuild();
         // TODO check that we haven't
         loop {
             if let Err(stop_reason) = self.run_one(rules) {

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -46,13 +46,14 @@ fn prove_something(name: &str, start: &str, rewrites: &[Rewrite<Prop, ()>], goal
     let start_expr: RecExpr<Prop> = start.parse().unwrap();
     let goal_exprs: Vec<RecExpr<Prop>> = goals.iter().map(|g| g.parse().unwrap()).collect();
 
-    let egraph = Runner::new()
+    let mut egraph = Runner::new()
         .with_iter_limit(20)
         .with_node_limit(5_000)
         .with_expr(&start_expr)
         .run(rewrites)
         .egraph;
 
+    egraph.rebuild();
     for (i, (goal_expr, goal_str)) in goal_exprs.iter().zip(goals).enumerate() {
         println!("Trying to prove goal {}: {}", i, goal_str);
         let equivs = egraph.equivs(&start_expr, &goal_expr);
@@ -149,6 +150,7 @@ fn const_fold() {
     let start_expr = start.parse().unwrap();
     let end = "false";
     let end_expr = end.parse().unwrap();
-    let (eg, _) = EGraph::from_expr(&start_expr);
+    let (mut eg, _) = EGraph::from_expr(&start_expr);
+    eg.rebuild();
     assert!(!eg.equivs(&start_expr, &end_expr).is_empty());
 }

--- a/tests/prop.rs
+++ b/tests/prop.rs
@@ -46,14 +46,13 @@ fn prove_something(name: &str, start: &str, rewrites: &[Rewrite<Prop, ()>], goal
     let start_expr: RecExpr<Prop> = start.parse().unwrap();
     let goal_exprs: Vec<RecExpr<Prop>> = goals.iter().map(|g| g.parse().unwrap()).collect();
 
-    let mut egraph = Runner::new()
+    let egraph = Runner::new()
         .with_iter_limit(20)
         .with_node_limit(5_000)
         .with_expr(&start_expr)
         .run(rewrites)
         .egraph;
 
-    egraph.rebuild();
     for (i, (goal_expr, goal_str)) in goal_exprs.iter().zip(goals).enumerate() {
         println!("Trying to prove goal {}: {}", i, goal_str);
         let equivs = egraph.equivs(&start_expr, &goal_expr);


### PR DESCRIPTION
This PR adds a hash table from the "signature" of the top level of a rule, which is the operator and the number of children, to eclasses that contain that signature at least once. For a given rule, it allows us to skip over eclasses that could not contain any matches for the rule because they do not contain an enode of the correct signature.

Timing with the rules from Herbie, this leads to a 3X speedup in searching (1.5X overall speedup) regardless of the node limit.
@mwillsey , could you please run whatever benchmarking you usually do on this PR and see what you find?