### PR TITLE
Efficient version of egraph.add_expr and extractor.find_best

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -314,7 +314,7 @@ impl<L: Language, N: Analysis<L>> EGraph<L, N> {
                 assert!(added_memo.insert(e.clone(), id).is_none());
                 log::trace!("Added!! expr {:?}", expr);
                 id
-            },
+            }
         }
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -201,7 +201,12 @@ where
         (cost, expr)
     }
 
-    fn find_best_rec(&mut self, expr: &mut RecExpr<L>, eclass: Id, added_memo: &mut HashMap<Id, Id>) -> (Id, CF::Cost) {
+    fn find_best_rec(
+        &mut self,
+        expr: &mut RecExpr<L>,
+        eclass: Id,
+        added_memo: &mut HashMap<Id, Id>,
+    ) -> (Id, CF::Cost) {
         let id = self.egraph.find(eclass);
         let (best_cost, best_node) = match self.costs.get(&id) {
             Some(result) => result.clone(),
@@ -211,11 +216,12 @@ where
         match added_memo.get(&id) {
             Some(id_expr) => (*id_expr, best_cost),
             None => {
-                let node = best_node.map_children(|child| self.find_best_rec(expr, child, added_memo).0);
+                let node =
+                    best_node.map_children(|child| self.find_best_rec(expr, child, added_memo).0);
                 let id_expr = expr.add(node);
                 assert!(added_memo.insert(id, id_expr).is_none());
                 (id_expr, best_cost)
-            },
+            }
         }
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -195,19 +195,28 @@ where
     /// given eclass.
     pub fn find_best(&mut self, eclass: Id) -> (CF::Cost, RecExpr<L>) {
         let mut expr = RecExpr::default();
-        let (_, cost) = self.find_best_rec(&mut expr, eclass);
+        // added_memo maps eclass id to id in expr
+        let mut added_memo: HashMap<Id, Id> = Default::default();
+        let (_, cost) = self.find_best_rec(&mut expr, eclass, &mut added_memo);
         (cost, expr)
     }
 
-    fn find_best_rec(&mut self, expr: &mut RecExpr<L>, eclass: Id) -> (Id, CF::Cost) {
+    fn find_best_rec(&mut self, expr: &mut RecExpr<L>, eclass: Id, added_memo: &mut HashMap<Id, Id>) -> (Id, CF::Cost) {
         let id = self.egraph.find(eclass);
         let (best_cost, best_node) = match self.costs.get(&id) {
             Some(result) => result.clone(),
             None => panic!("Failed to extract from eclass {}", id),
         };
 
-        let node = best_node.map_children(|child| self.find_best_rec(expr, child).0);
-        (expr.add(node), best_cost)
+        match added_memo.get(&id) {
+            Some(id_expr) => (*id_expr, best_cost),
+            None => {
+                let node = best_node.map_children(|child| self.find_best_rec(expr, child, added_memo).0);
+                let id_expr = expr.add(node);
+                assert!(added_memo.insert(id, id_expr).is_none());
+                (id_expr, best_cost)
+            },
+        }
     }
 
     fn node_total_cost(&mut self, node: &L) -> Option<CF::Cost> {


### PR DESCRIPTION
Add memoization to egraph.add_expr and extractor.find_best. On larger graphs, this gives a lot of speed up (changing from exponential to linear time). 

Run time comparison, on benchnet from https://github.com/yycdavid/tamago (~200 nodes):
-- add_expr: 
old version 1747s
new version 2.26s
-- find_best:
old version: 1177s
new version: 0.00123s